### PR TITLE
properly forward errors on exec, return 123 on any exit status 1-254

### DIFF
--- a/t/errors.t
+++ b/t/errors.t
@@ -1,7 +1,7 @@
 #!/bin/sh
 export "PATH=.:$PATH"
 
-printf '1..13\n'
+printf '1..16\n'
 printf '# error handling\n'
 
 tap3 'exit code on success' <<'EOF'
@@ -16,6 +16,27 @@ EOF
 
 tap3 'exit code on when command fails with 1-125' <<'EOF'
 xe -s 'exit 42'
+<<<
+a
+>>>= 123
+EOF
+
+tap3 'exit code on when command fails with 126' <<'EOF'
+xe -s 'exit 126'
+<<<
+a
+>>>= 123
+EOF
+
+tap3 'exit code on when command fails with 127' <<'EOF'
+xe -s 'exit 127'
+<<<
+a
+>>>= 123
+EOF
+
+tap3 'exit code on when command fails with 250' <<'EOF'
+xe -s 'exit 250'
 <<<
 a
 >>>= 123

--- a/xe.1
+++ b/xe.1
@@ -1,4 +1,4 @@
-.Dd November 3, 2017
+.Dd August 1, 2023
 .Dt XE 1
 .Os
 .Sh NAME
@@ -247,7 +247,7 @@ follows the convention of GNU and OpenBSD xargs:
 .It 0
 on success
 .It 123
-if any invocation of the command exited with status 1 to 125.
+if any invocation of the command exited with status 1 to 254.
 .It 124
 if the command exited with status 255
 .It 125


### PR DESCRIPTION
Use the CLOEXEC pipe trick to detect if exec happened; read the errno from the pipe if it wasn't closed due to exec.

Fixes #6.