### PR TITLE
Makefile: respect user CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ALL=xe
 ZSHCOMP=_xe
 
-CFLAGS=-g -O2 -Wall -Wno-switch -Wextra -Wwrite-strings
+CFLAGS:=-g -O2 -Wall -Wno-switch -Wextra -Wwrite-strings $(CFLAGS)
 
 DESTDIR=
 PREFIX=/usr/local


### PR DESCRIPTION
The motivation for this change is that downstream distributions such as Gentoo Linux require build systems to respect the user's CFLAGS: https://bugs.gentoo.org/931796
For the sake of configurability, would you be open to accept a patch to remove `-g -O2` from CFLAGS?

Thank you for your time!